### PR TITLE
Added --recurse-submodules to clone instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Whip up the terminal, and make sure the following are installed:
 Then, download our code and compile it:
 
 ```bash
-git clone https://github.com/SpadeMC/Spade
+git clone --recurse-submodules https://github.com/SpadeMC/Spade
 cd Spade
 make
 ```


### PR DESCRIPTION
Previous instructions failed to clone the submodules we use for dependencies