### PR TITLE
Makes the `compile` function defined on multiple lines

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -50,4 +50,9 @@ main = do
             exitFailure
 
 compile :: Args -> String -> Result [(FilePath,String)]
-compile a s = parseString a s >>= resolveScope a >>= checkTypes a >>= processConstants a >>= optimise a >>= generate a
+compile a s = parseString a s
+    >>= resolveScope a
+    >>= checkTypes a
+    >>= processConstants a
+    >>= optimise a
+    >>= generate a


### PR DESCRIPTION
Avoids merge conflicts when adding new stages.