### PR TITLE
Change integer type from Integer to Int32

### DIFF
--- a/src/Language/AST.hs
+++ b/src/Language/AST.hs
@@ -152,7 +152,7 @@ data RangeDef
 
 -- | Data-structure to represent a single value
 data Value
-    = IntegerV Integer SpadeType AlexPosn
+    = IntegerV Int32 SpadeType AlexPosn
     | DoubleV Double SpadeType AlexPosn
     | StringV String SpadeType AlexPosn
     | IdentV Ident SpadeType AlexPosn

--- a/src/Language/SpadeParser.y.m4
+++ b/src/Language/SpadeParser.y.m4
@@ -212,7 +212,7 @@ expr : value                   { Value $1 (Unknown UnknownM) (getPos $1) }
      | "(" expr ")"            { Brackets $2 (getPos $1) }
 
 value :: {Value}
-value : INT                  			  { IntegerV (intVal $1) (Unknown UnknownM) (getPos $1) }
+value : INT                  			  { IntegerV (fromIntegral (intVal $1)) (Unknown UnknownM) (getPos $1) }
       | REAL                 			  { DoubleV (realVal $1) (Unknown UnknownM) (getPos $1) }
       | STRING               			  { StringV (stringVal $1) (Unknown UnknownM) (getPos $1) }
       | IDENT                			  { IdentV (Ident (identifierVal $1) (getPos $1)) (Unknown UnknownM) (getPos $1) }


### PR DESCRIPTION
### Problem description

Integers should be 32-bit to match other integer types.

### How this PR fixes the problem

Changes type to In32 and converts it in the parser.